### PR TITLE
Added support for --working-dir

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -35,7 +35,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         $vendor_dir = str_replace('\'', '\\\'', realpath($this->composer->getConfig()->get('vendor-dir')));
         $base_dir   = str_replace('\'', '\\\'', getcwd());
         file_put_contents(
-            __DIR__ . '/Path.php',
+            $vendor_dir . '/hostnet/path-composer-plugin-lib/src/Path.php',
             <<<EOF
 <?php
 namespace Hostnet\Component\Path;


### PR DESCRIPTION
When using the composer `--working-dir` option and build it in another repository than currently using, it will put the generated file in the wrong location.