### PR TITLE
Made tests less fragile by removing path file

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -35,9 +35,11 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         $vendor_dir = str_replace('\'', '\\\'', realpath($this->composer->getConfig()->get('vendor-dir')));
         $base_dir   = str_replace('\'', '\\\'', getcwd());
 
-        $path = 0 === strpos(__DIR__, $vendor_dir)
-            ? __DIR__ . '/'
-            : $vendor_dir . '/hostnet/path-composer-plugin-lib/src/';
+        if (0 === strpos(__DIR__, $vendor_dir) || strlen(__DIR__) - 4 === strpos(__DIR__, '/src')) {
+            $path = __DIR__ . '/';
+        } else {
+            $path = $vendor_dir . '/hostnet/path-composer-plugin-lib/src/';
+        }
 
         file_put_contents(
             $path . 'Path.php',

--- a/test/PluginTest.php
+++ b/test/PluginTest.php
@@ -7,7 +7,7 @@ use Composer\IO\NullIO;
 use Composer\Script\ScriptEvents;
 
 /**
- * @covers Hostnet\Component\Path\Plugin
+ * @covers \Hostnet\Component\Path\Plugin
  */
 class PluginTest extends \PHPUnit_Framework_TestCase
 {
@@ -16,9 +16,14 @@ class PluginTest extends \PHPUnit_Framework_TestCase
      */
     private $plugin;
 
+    protected function setUp()
+    {
+        $this->plugin = new Plugin();
+    }
+
     public function testGetSubscribedEvents()
     {
-        $this->assertSame(
+        self::assertSame(
             [ScriptEvents::PRE_AUTOLOAD_DUMP => 'onPreAutoloadDump'],
             $this->plugin->getSubscribedEvents()
         );
@@ -35,12 +40,12 @@ class PluginTest extends \PHPUnit_Framework_TestCase
         // Test if Path.php will be created with valid contents
         $this->plugin->onPreAutoloadDump();
 
-        $this->assertEquals(realpath(__DIR__ . '/..'), Path::BASE_DIR);
-        $this->assertEquals(realpath(__DIR__ . '/../vendor'), Path::VENDOR_DIR);
+        self::assertEquals(realpath(__DIR__ . '/..'), Path::BASE_DIR);
+        self::assertEquals(realpath(__DIR__ . '/../vendor'), Path::VENDOR_DIR);
     }
 
-    protected function setUp()
+    protected function tearDown()
     {
-        $this->plugin = new Plugin();
+        @unlink(__DIR__ . '/../src/Path.php');
     }
 }


### PR DESCRIPTION
I've missed one case that broke only when running tests in this package. Because the `Path.php` was never removed in the tests, I didn't realize this case was broken.