### PR TITLE
lock composer version to v1 branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "class": "Hostnet\\Component\\Path\\Plugin"
     },
     "require-dev": {
-        "composer/composer": "@alpha",
+        "composer/composer": "^1.0",
         "phpunit/phpunit":   "^5.2",
         "squizlabs/php_codesniffer": "^2.5"
     }


### PR DESCRIPTION
composer/composer released a new alpha-tag, which is in the v2 branch
The library is not compatible with the composer-plugin-api v2