### PR TITLE
Implement missing PluginInterface methods for v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
         "class": "Hostnet\\Component\\Path\\Plugin"
     },
     "require-dev": {
-        "composer/composer": "^1.0",
-        "phpunit/phpunit":   "^5.2",
-        "squizlabs/php_codesniffer": "^2.5"
+        "composer/composer": "^2.0",
+        "phpunit/phpunit":   "^5.7",
+        "squizlabs/php_codesniffer": "^2.9"
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -30,16 +30,34 @@ class Plugin implements PluginInterface, EventSubscriberInterface
         $this->io       = $io;
     }
 
-    public function onPreAutoloadDump()
+    private function getVendorDir()
     {
-        $vendor_dir = str_replace('\'', '\\\'', realpath($this->composer->getConfig()->get('vendor-dir')));
-        $base_dir   = str_replace('\'', '\\\'', getcwd());
+        return str_replace('\'', '\\\'', realpath($this->composer->getConfig()->get('vendor-dir')));
+    }
+
+    private function getBaseDir()
+    {
+        return str_replace('\'', '\\\'', getcwd());
+    }
+
+    private function getPath()
+    {
+        $vendor_dir = $this->getVendorDir();
 
         if (0 === strpos(__DIR__, $vendor_dir) || strlen(__DIR__) - 4 === strpos(__DIR__, '/src')) {
             $path = __DIR__ . '/';
         } else {
             $path = $vendor_dir . '/hostnet/path-composer-plugin-lib/src/';
         }
+
+        return $path;
+    }
+
+    public function onPreAutoloadDump()
+    {
+        $path = $this->getPath();
+        $vendor_dir = $this->getVendorDir();
+        $base_dir = $this->getBaseDir();
 
         file_put_contents(
             $path . 'Path.php',
@@ -55,5 +73,14 @@ class Path
 
 EOF
         );
+    }
+
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+    }
+
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+        unlink($this->getPath() . 'Path.php');
     }
 }


### PR DESCRIPTION
Fixes:

`Fatal error: Class Hostnet\Component\Path\Plugin contains 2 abstract methods and must therefore be declared abstract or implement the remaining methods (Composer\Plugin\PluginInterface::deactivate, Composer\Plugin\PluginInterface::uninstall)`
